### PR TITLE
Add initial AcidGas class

### DIFF
--- a/src/pHcalc/__init__.py
+++ b/src/pHcalc/__init__.py
@@ -1,1 +1,1 @@
-from .pHcalc import Acid, Inert, System
+from .pHcalc import Acid, AcidGas, Inert, System

--- a/src/pHcalc/pHcalc.py
+++ b/src/pHcalc/pHcalc.py
@@ -183,6 +183,23 @@ class Acid(object):
             return h3o_Ka/den
 
 
+class AcidGas(Acid):
+    def __init__(self, *args, Hs=None, Pgas=None, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.gas_conc = Hs*Pgas
+        self.conc = self.gas_conc
+        self.gas_idx = np.argmin( np.abs( self.charge ) )
+
+
+    def alpha(self, pH):
+        alphas = super().alpha(pH)
+
+        self.conc = self.gas_conc/alphas[self.gas_idx]
+
+        return alphas
+        
+
 class System(object):
     '''An object used to define an a system of acid and neutral species.
 
@@ -253,11 +270,12 @@ class System(object):
         # Go through all the species that were given, and sum up their
         # charge*concentration values into our total sum.
         for s in self.species:
+            alphas = s.alpha(pH)
             if twoD == False:
-                x += (s.conc*s.charge*s.alpha(pH)).sum()
+                x += (s.conc*s.charge*alphas).sum()
             else:
-                x += (s.conc*s.charge*s.alpha(pH)).sum(axis=1)
-        
+                x += (s.conc*s.charge*alphas).sum(axis=1)
+
         # Return the absolute value so it never goes below zero.
         return np.abs(x)
         


### PR DESCRIPTION
This can be used for gasses that participate in acid/base equilibria

Can be used for atmospheric CO2, for example. In the _diff_pos_neg method of the System class, the alpha value calculation is moved out of the if/else to ensure that the new concentrations are calculated correctly

Compare to @mhverts nice GH-6 which does something similar but with a System subclass.

See example usage here: https://gist.github.com/rnelsonchem/709d64446b042127191bc03892d142c0