### PR TITLE
Added titration method to solve for concentrations of a system of chemical species which produce a target pH

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/pHcalc.iml" filepath="$PROJECT_DIR$/.idea/pHcalc.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/pHcalc.iml
+++ b/.idea/pHcalc.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="NUMPY" />
+    <option name="myDocStringFormat" value="NumPy" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/pHcalc/pHcalc.py
+++ b/src/pHcalc/pHcalc.py
@@ -396,7 +396,7 @@ class System:
         if guess is None:
             guess = [0.010] * len(self.species)
 
-        self.conc_solution = spo.minimize(self._diff_pos_neg, guess,
+        self.conc_solution = spo.minimize(self._diff_pos_neg_conc, guess,
                                        method=method, tol=tol)
 
         if self.conc_solution.success == False:
@@ -436,6 +436,18 @@ if __name__ == '__main__':
     s.pHsolve()
     print('(NH4)3PO4 1e-3 M pH = ', s.pH)
     print()
+
+    # As a test case for concentration solution, solve for
+    # concentrations yielding pH 4.0 for combinations of NH4
+    # and H3PO4
+    s.conc_solve([0.002, 0.05], 4.0)
+    print('Suggested concentrations for pH 4.0 = ', s.target_concs)
+    # Confirm that the solution given evaluates to the target pH.
+    a = Acid(pKa=[2.148, 7.198, 12.375], charge=0, conc=s.target_concs[0])
+    b = Acid(pKa=9.498, charge=1, conc=s.target_concs[1])
+    s = System(a, b)
+    s.pHsolve()
+    print('Suggested concentrations yield pH = ', s.pH)
 
     try:
         import matplotlib.pyplot as plt

--- a/src/pHcalc/pHcalc.py
+++ b/src/pHcalc/pHcalc.py
@@ -1,7 +1,45 @@
 import numpy as np
 import scipy.optimize as spo
 
-class Inert:
+
+def default_conductivity():
+    return [0] * 4
+
+
+class ConductiveSpecies:
+    """A nonreactive ion class.
+
+    This object defines constants for a cubic regression of a species'
+    contribution to conductivity in a solution, and defines a simple
+    method to approximate the additional conductivity conferred by the
+    species in mS/cm. This method of approximating conductivity is not
+    scientifically rigorous, but with good regressions shows accuracy
+    within ±5% or so.
+
+    Parameters
+    ----------
+    constants : list
+        The formal charge of the ion.
+
+    Attributes
+    ----------
+    constants : list
+        The formal charge of the ion.
+
+    """
+    def __init__(self, constants=default_conductivity):
+        self.conductivity = constants
+
+    def component_cond(self, concentration):
+        # The existing classes use Molar units instead of milli molar units.
+        # Convert to milli molar units to use existing regressions.
+        working_conc = concentration * 1000
+        regression = list(self.conductivity)
+        return (regression[0] * working_conc ** 3) + (regression[1] * working_conc ** 2) + \
+               (regression[2] * working_conc) + regression[3]
+
+
+class Inert(ConductiveSpecies):
     """A nonreactive ion class.
 
     This object defines things like K+ and Cl-, which contribute to the
@@ -25,7 +63,8 @@ class Inert:
         The concentration of this species in solution.
 
     """
-    def __init__(self, charge=None, conc=None):
+    def __init__(self, charge=None, conc=None, constants=None):
+        super().__init__(constants)
         if charge == None:
             raise ValueError(
                 "The charge for this ion must be defined.")
@@ -58,8 +97,7 @@ class Inert:
         return ones
 
 
-        
-class Acid:
+class Acid(ConductiveSpecies):
     '''An acidic species class.
 
     This object is used to calculate a number of parameters related to a weak
@@ -93,7 +131,8 @@ class Acid:
     examples.
 
     '''
-    def __init__(self, Ka=None, pKa=None, charge=None, conc=None):
+    def __init__(self, Ka=None, pKa=None, charge=None, conc=None, constants=None):
+        super().__init__(constants)
         # Do a couple quick checks to make sure that everything has been
         # defined.
         if Ka == None and pKa == None:
@@ -330,9 +369,8 @@ class System:
 
         Parameters
         ----------
-        pH : int, float, or Numpy Array
-            The pH value(s) used to calculate the different distributions of
-            positive and negative species.
+        concs : list or Numpy Array
+            The concentrations for each species in the system
 
         Returns
         -------
@@ -358,7 +396,43 @@ class System:
         # "minimize" to a sub optimal solution.
         return np.abs(x)
 
-    def conc_solve(self, guess, target_ph, method='Nelder-Mead', tol=1e-5):
+    def cond_solve(self, concs=None):
+        '''Calculate the charge balance difference.
+
+        Parameters
+        ----------
+        concs : list or Numpy Array
+            The concentrations for each species in the system
+
+        Returns
+        -------
+        float or Numpy Array
+            The absolute value of the difference in concentration between the
+            positive and negatively charged species in the system. A float is
+            returned if an int or float is input as the pH: a Numpy array is
+            returned if an array of pH values is used as the input.
+        '''
+        x = 0.0
+
+        # Sum up the conductivity components of all species in the system at the
+        # concs to be assessed.
+        for species_index in range(len(self.species)):
+            if concs is not None:
+                x += self.species[species_index].component_cond(concs[species_index])
+            else:
+                x += self.species[species_index].component_cond(self.species[species_index].conc)
+
+        self.mS = x
+
+    def _diff_cond(self, concs, target):
+        self.cond_solve(concs)
+        return np.abs(self.mS - target)
+
+    def _diff_complete(self, concs, cond_target):
+        # Weight the value of _diff_pos_neg_conc to ensure that pH is accounted for adequately
+        return self._diff_cond(concs, cond_target) + 10000 * self._diff_pos_neg_conc(concs)
+
+    def conc_solve(self, target_ph, method='Nelder-Mead', tol=1e-5, guess=None):
         '''Solve for an array of concentrations yielding the desired pH.
 
         The solution is derived using a simple minimization function.
@@ -396,8 +470,107 @@ class System:
         if guess is None:
             guess = [0.010] * len(self.species)
 
+        conc_bounds = [(0.0, 3.5)] * len(self.species)
         self.conc_solution = spo.minimize(self._diff_pos_neg_conc, guess,
-                                       method=method, tol=tol)
+                                       method=method, tol=tol, bounds=conc_bounds)
+
+        if self.conc_solution.success == False:
+            print('Warning: Unsuccessful pH optimization!')
+            print(self.conc_solution.message)
+        else:
+            self.target_concs = self.conc_solution.x
+
+    # TODO Rewrite this whole function
+    def conc_solve_cond(self, guess, target_cond, method='Nelder-Mead', tol=1e-5):
+        '''Solve for an array of concentrations yielding the desired pH.
+
+        The solution is derived using a simple minimization function.
+        The function to evaluate simply calculates the conductivity of
+        a system of chemicals, and then takes the absolute value of the
+        difference between the target_cond parameter and the predicted
+        conductivity of the system defined by an array of concentrations.
+
+        Parameters
+        ----------
+
+        guess : float (default [0.010] * len(self.species))
+            This is a list defining the concentrations for each species to use
+            for an initial guess.
+
+        target_cond : float
+            This is the conductivity for which the method should identify a combination
+            of concentration values for the species in the system.
+
+        method : str (default 'Nelder-Mead')
+            The minimization method used to find the concs. The possible values
+            for this variable are defined in the documentation for the
+            scipy.optimize.minimize function.
+
+        tol : float (default 1e-5)
+            The tolerance used to determine convergence of the minimization
+            function.
+        '''
+
+        # There's probably a more pythonic way to set this default.
+        if guess is None:
+            guess = [0.010] * len(self.species)
+
+        conc_bounds = [(0.010, 3.5)] * len(self.species)
+        self.conc_solution = spo.minimize(self._diff_cond, args=(guess, target_cond),
+                                       method=method, tol=tol, bounds=conc_bounds)
+
+        if self.conc_solution.success == False:
+            print('Warning: Unsuccessful conductivity optimization!')
+            print(self.conc_solution.message)
+        else:
+            self.target_concs = self.conc_solution.x
+
+    # TODO Rewrite this whole function
+    def conc_solve_complete(self, target_ph, target_cond, method='Nelder-Mead', tol=1e-5, guess=None):
+        '''Solve for an array of concentrations yielding the desired pH
+        and conductivity.
+
+        The solution is derived using a simple minimization function.
+        The value to be minimized is the sum of error in positive and
+        negative ion concentration in solution, and deviation of
+        conductivity from the target value.
+
+        Parameters related to guess_est in the standard pHsolve method
+        have been removed for simplicity's sake during initial dev.
+
+        Parameters
+        ----------
+
+        guess : float (default [0.010] * len(self.species))
+            This is a list defining the concentrations for each species to use
+            for an initial guess.
+
+        target_ph : float
+            This is the pH for which the method should identify a combination
+            of concentration values for the species in the system.
+
+        target_cond : float
+            This is the conductivity for which the method should identify a combination
+            of concentration values for the species in the system.
+
+        method : str (default 'Nelder-Mead')
+            The minimization method used to find the concs. The possible values
+            for this variable are defined in the documentation for the
+            scipy.optimize.minimize function.
+
+        tol : float (default 1e-5)
+            The tolerance used to determine convergence of the minimization
+            function.
+        '''
+
+        self.pH = target_ph
+        # There's probably a more pythonic way to set this default.
+        if guess is None:
+            guess = [0.010] * len(self.species)
+
+        conc_bounds = [(0.010, 3.5)] * len(self.species)
+        self.conc_solution = spo.minimize(self._diff_complete, guess, args=(target_cond),
+                                          method=method, tol=tol, bounds=conc_bounds)
 
         if self.conc_solution.success == False:
             print('Warning: Unsuccessful pH optimization!')
@@ -437,17 +610,30 @@ if __name__ == '__main__':
     print('(NH4)3PO4 1e-3 M pH = ', s.pH)
     print()
 
-    # As a test case for concentration solution, solve for
-    # concentrations yielding pH 4.0 for combinations of NH4
-    # and H3PO4
-    s.conc_solve([0.002, 0.05], 4.0)
-    print('Suggested concentrations for pH 4.0 = ', s.target_concs)
-    # Confirm that the solution given evaluates to the target pH.
-    a = Acid(pKa=[2.148, 7.198, 12.375], charge=0, conc=s.target_concs[0])
-    b = Acid(pKa=9.498, charge=1, conc=s.target_concs[1])
-    s = System(a, b)
+    # Test ability to solve for a buffer satisfying conductivity
+    # and pH target constraints.
+    a = Acid(pKa=[8.06], charge=1, conc=0.01, constants=[0.0, 0.0, 0.0002, 0])
+    b = Acid(pKa=[4.75], charge=0, conc=0.05, constants=[0.0, 0.0, 0.0064, 0])
+    c = Acid(pKa=[0], charge=1, conc=0.2, constants=[0.0000000002, -0.00001, 0.1095, 0.0])
+    s = System(a, b, c)
     s.pHsolve()
-    print('Suggested concentrations yield pH = ', s.pH)
+    s.cond_solve()
+    print('Test Buffer pH = ', s.pH)
+    print('Test Buffer mS = ', s.mS)
+    print()
+    print('Solving for pH 3.2 and 55mS')
+    s.conc_solve_complete(3.2, 55.0)
+    print('Target Concentrations = ', s.target_concs)
+    suggested_concs = s.target_concs
+    # Verify the chemical properties of the suggested buffer
+    a = Acid(pKa=[8.06], charge=1, conc=suggested_concs[0], constants=[0.0, 0.0, 0.0002, 0])
+    b = Acid(pKa=[4.75], charge=0, conc=suggested_concs[1], constants=[0.0, 0.0, 0.0064, 0])
+    c = Acid(pKa=[0], charge=1, conc=suggested_concs[2], constants=[0.0000000002, -0.00001, 0.1095, 0.0])
+    s = System(a, b, c)
+    s.pHsolve()
+    s.cond_solve()
+    print('Suggested Buffer pH = ', s.pH)
+    print('Suggested Buffer mS = ', s.mS)
 
     try:
         import matplotlib.pyplot as plt

--- a/src/pHcalc/pHcalc.py
+++ b/src/pHcalc/pHcalc.py
@@ -358,7 +358,7 @@ class System:
         # "minimize" to a sub optimal solution.
         return np.abs(x)
 
-    def conc_solve(self, guess, method='Nelder-Mead', tol=1e-5):
+    def conc_solve(self, guess, target_ph, method='Nelder-Mead', tol=1e-5):
         '''Solve for an array of concentrations yielding the desired pH.
 
         The solution is derived using a simple minimization function.
@@ -374,10 +374,15 @@ class System:
         ----------
 
         guess : float (default 7.0)
-            This is used as the initial guess of the pH for the system.
+            This is a list defining the concentrations for each species to use
+            for an initial guess.
+
+        target_ph : float
+            This is the pH for which the method should identify a combination
+            of concentration values for the species in the system.
 
         method : str (default 'Nelder-Mead')
-            The minimization method used to find the pH. The possible values
+            The minimization method used to find the concs. The possible values
             for this variable are defined in the documentation for the
             scipy.optimize.minimize function.
 
@@ -386,6 +391,7 @@ class System:
             function.
         '''
 
+        self.pH = target_ph
         # There's probably a more pythonic way to set this default.
         if guess is None:
             guess = [0.010] * len(self.species)


### PR DESCRIPTION
This PR adds the following features:

- conc_solve method takes a target pH value, and will search for concentrations of constituent species in a system which will attain the desired pH value. This implementation is much faster computationally speaking than running minimize on a function which in turn calls the .pHsolve method with its own minimization function.
- cond_solve method approximates the conductivity of a system given some cubic regressions modelling how those species contribute to the conductivity of a solution. This may be slightly outside of the scope of what the pHcalc library really seeks to do, but for our application bundling this feature in with the pH calcs presents a lot of improvements.
- conc_solve_cond takes a target conductivity value, and suggests molar concentrations of constituent species which will achieve that target conductivity (in mS / cm)
- conc_solve_complete takes both target conductivity and pH, and will solve for a system of chemical species yielding those pH and conductivity values.

I tried to follow the style of the existing library, but may have deviated in some places. Please let me know if there are any stylistic notes that I should change. If the additional functionality relating to conductivity is not of interest to you, the pH buffer solution component is stable in the third commit of my branch, and everything relating to conductivity was added in the fourth commit.